### PR TITLE
chore: rename LanguageValues to LocalizedStrings

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -83,11 +83,11 @@ components:
           type: string
           description: Status of concept, full uri if part of EU published concept statuses
         preferredTerm:
-          $ref: "#/components/schemas/LanguageValues"
+          $ref: "#/components/schemas/LocalizedStrings"
         definition:
           $ref: "#/components/schemas/Definition"
         note:
-          $ref: "#/components/schemas/LanguageValues"
+          $ref: "#/components/schemas/LocalizedStrings"
         valueRange:
           $ref: "#/components/schemas/URIText"
         contactPoint:
@@ -95,7 +95,7 @@ components:
         abbreviatedLabel:
           type: string
         example:
-          $ref: "#/components/schemas/LanguageValues"
+          $ref: "#/components/schemas/LocalizedStrings"
         dateValidFrom:
           type: string
           format: date
@@ -123,7 +123,7 @@ components:
       type: object
       properties:
         text:
-          $ref: "#/components/schemas/LanguageValues"
+          $ref: "#/components/schemas/LocalizedStrings"
         sourceDescription:
           $ref: "#/components/schemas/SourceDescription"
 
@@ -144,7 +144,7 @@ components:
           type: integer
           minimum: 0
 
-    LanguageValues:
+    LocalizedStrings:
       type: object
       properties:
         nb:

--- a/src/main/kotlin/no/digdir/catalog_view_api/model/Concept.kt
+++ b/src/main/kotlin/no/digdir/catalog_view_api/model/Concept.kt
@@ -12,13 +12,13 @@ data class Concept(
     val version: SemVer,
     val publisher: String,
     val status: String?,
-    val preferredTerm: LanguageValues?,
+    val preferredTerm: LocalizedStrings?,
     val definition: Definition?,
-    val note: LanguageValues?,
+    val note: LocalizedStrings?,
     val valueRange: URIText?,
     val contactPoint: ContactPoint?,
     val abbreviatedLabel: String?,
-    val example: LanguageValues?,
+    val example: LocalizedStrings?,
     val dateValidFrom: LocalDate?,
     val dateValidThrough: LocalDate?,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "Europe/Oslo")
@@ -30,7 +30,7 @@ data class Concept(
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-data class LanguageValues(
+data class LocalizedStrings(
     val nb: String?,
     val nn: String?,
     val en: String?
@@ -38,7 +38,7 @@ data class LanguageValues(
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class Definition (
-    val text: LanguageValues?,
+    val text: LocalizedStrings?,
     val sourceDescription: SourceDescription?
 )
 

--- a/src/main/kotlin/no/digdir/catalog_view_api/service/ConceptsService.kt
+++ b/src/main/kotlin/no/digdir/catalog_view_api/service/ConceptsService.kt
@@ -52,8 +52,8 @@ fun InternalConcept.toExternalDTO(): Concept =
         lastChangedBy = endringslogelement?.endretAv
     )
 
-private fun Map<String, String>.toLangValueObject(): LanguageValues? {
-    val langValues = LanguageValues(
+private fun Map<String, String>.toLangValueObject(): LocalizedStrings? {
+    val langValues = LocalizedStrings(
         nb = get("nb")?.ifBlank { null },
         nn = get("nn")?.ifBlank { null },
         en = get("en")?.ifBlank { null }

--- a/src/test/kotlin/no/digdir/catalog_view_api/unit/ConceptMapper.kt
+++ b/src/test/kotlin/no/digdir/catalog_view_api/unit/ConceptMapper.kt
@@ -23,7 +23,7 @@ class ConceptMapper {
     @Test
     fun `Map preferred term`() {
         val expected = EMPTY_CONCEPT.copy(
-            preferredTerm = LanguageValues(
+            preferredTerm = LocalizedStrings(
                 nb = "bokmål",
                 nn = "nynorsk",
                 en = "english"
@@ -45,7 +45,7 @@ class ConceptMapper {
     fun `Map definition`() {
         val expected = EMPTY_CONCEPT.copy(
             definition = Definition(
-                text = LanguageValues(
+                text = LocalizedStrings(
                     nb = "bokmål",
                     nn = "nynorsk",
                     en = "english"),
@@ -81,7 +81,7 @@ class ConceptMapper {
     @Test
     fun `Map note`() {
         val expected = EMPTY_CONCEPT.copy(
-            note = LanguageValues(
+            note = LocalizedStrings(
                 nb = "bokmål",
                 nn = "nynorsk",
                 en = "english"
@@ -102,7 +102,7 @@ class ConceptMapper {
     @Test
     fun `Map example`() {
         val expected = EMPTY_CONCEPT.copy(
-            example = LanguageValues(
+            example = LocalizedStrings(
                 nb = "bokmål",
                 nn = "nynorsk",
                 en = "english"


### PR DESCRIPTION
Forslaget fra Jeff var å endre til `LocalizedStrings` som vi bruker i feks fdk-portal. Men hovedpoenget blir å samkjøre navnet på slike objekt på tvers av løsningene våre, så kjør på om du har andre forslag