### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,5 +1,8 @@
 name: Code scanning (CodeQL)
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [ready_for_review, opened, reopened, synchronize]

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -2,6 +2,7 @@ name: Code scanning (CodeQL)
 
 permissions:
   contents: read
+  security-events: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Informasjonsforvaltning/catalog-view-api/security/code-scanning/7](https://github.com/Informasjonsforvaltning/catalog-view-api/security/code-scanning/7)

In general, the fix is to add an explicit `permissions` block that restricts the `GITHUB_TOKEN` to the least privileges needed. For a CodeQL analysis workflow that only needs to read the repository code and metadata, `contents: read` (and optionally `security-events: write` if the reusable workflow uploads results) is a common minimal set. Since we cannot see the contents of the reusable workflow, the safest minimal change that clearly reduces overbroad defaults without breaking standard CodeQL scanning is to set read-only repository access at the workflow root.

The single best way to fix this without changing behavior is:
- Add a top-level `permissions:` block (aligned with `name:` and `on:`) specifying read-only access to repository contents.
- This block will apply to all jobs in the workflow (here, just `codeql`) that do not have their own `permissions` key, satisfying the CodeQL rule and enforcing least privilege compared to the potentially read-write default.

Concrete change in `.github/workflows/codeql.yaml`:
- Insert after line 1 (after `name: Code scanning (CodeQL)`) a new permissions section:
  ```yaml
permissions:
  contents: read
  security-events: write
```
No imports or additional definitions are needed, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
