### PR TITLE
fix: bump httpclient5 to 5.6.3 (Dependabot #2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.6.1</version>
+            <version>5.6.3</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
Bumps `org.apache.httpcomponents.client5:httpclient5` to `5.6.3` to resolve Dependabot alert **#2** (Medium, `< 5.6.3`). Test-scoped patch bump; CI runs the full suite.