### PR TITLE
Bump httpcore5 and postgresql to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,10 @@
 
         <kotlin.version>2.4.10</kotlin.version>
         <testcontainers.version>2.0.5</testcontainers.version>
+        <!-- Overrides Spring Boot 4.1.0 (5.4.2), which is still affected by CVE-2026-54399 and CVE-2026-54428 -->
+        <httpcore5.version>5.4.3</httpcore5.version>
+        <!-- Overrides Spring Boot 4.1.0 (42.7.11), which is still affected by CVE-2026-54291 -->
+        <postgresql.version>42.7.13</postgresql.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
# Summary 

- Override `httpcore5.version` to `5.4.3`, fixing CVE-2026-54399 (HTTP/1.1 header memory exhaustion) and CVE-2026-54428 (HTTP/2 HPACK decoder).
- Override `postgresql.version` to `42.7.13`, fixing CVE-2026-54291; Spring Boot 4.1.0 still resolves 42.7.11.
- `httpclient5` was already at 5.6.4 on `main`, but Spring Boot 4.1.0 pins `httpcore5`/`httpcore5-h2` to 5.4.2 through its own BOM property, so only this override actually moves them.
